### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Freescale MMA7455 accelerometer sensor library
 paragraph=Freescale MMA7455 accelerometer sensor library
 category=Sensors
 url=https://github.com/ricki-z/MMA7455
-architectures=ESP8266
+architectures=esp8266


### PR DESCRIPTION
The previous architectures value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library MMA7455 claims to run on (ARCHITECTURE) architecture(s) and may be incompatible with your current board which runs on (esp8266) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the File > Examples > INCOMPATIBLE menu.